### PR TITLE
Fix: Compatibility v14 to prep_release

### DIFF
--- a/age-system.js
+++ b/age-system.js
@@ -523,7 +523,7 @@ Hooks.on(`getSceneControlButtons`, controls => {
                 "activate": true,
                 onChange: async (event, active) => {
                     let roll = await new Roll("1d6").evaluate();
-                    return roll.toMessage({}, {rollMode: event.shiftKey ? "blindroll" : ""});
+                    return roll.toMessage({}, {messageMode: event.shiftKey ? "blindroll" : ""})
                 }
             },
             "d66": {
@@ -534,7 +534,7 @@ Hooks.on(`getSceneControlButtons`, controls => {
                 "button": true,
                 onChange: async (event, active) => {
                     let roll = await new Roll("1d6*10 + 1d6").evaluate();
-                    return roll.toMessage({}, {rollMode: event.shiftKey ? "blindroll" : ""})
+                    return roll.toMessage({}, {messageMode: event.shiftKey ? "blindroll" : ""})
                 }
             },
             "d666": {
@@ -545,7 +545,7 @@ Hooks.on(`getSceneControlButtons`, controls => {
                 "button": true,
                 onChange: async (event, active) => {
                     let roll = await new Roll("1d6*100 + 1d6*10 + 1d6").evaluate();
-                    return roll.toMessage({}, {rollMode: event.shiftKey ? "blindroll" : ""})
+                    return roll.toMessage({}, {messageMode: event.shiftKey ? "blindroll" : ""})
                 }
             },
             // Figure out a way to select token when using this tool!!!

--- a/age-system.js
+++ b/age-system.js
@@ -102,8 +102,7 @@ Hooks.once("init", function() {
     };
 
     const Actors = foundry.documents.collections.Actors;
-    const ActorSheet = foundry.appv1.sheets.ActorSheet;
-    Actors.unregisterSheet("core", ActorSheet);
+    Actors.unregisterSheet("core", globalThis.ActorSheet);
     Actors.registerSheet("age-system", ageSystemSheetCharacter, {
         types: ["char"],
         makeDefault: true,
@@ -130,8 +129,7 @@ Hooks.once("init", function() {
     });
     
     const Items = foundry.documents.collections.Items;
-    const ItemSheet = foundry.appv1.sheets.ItemSheet;
-    Items.unregisterSheet("core", ItemSheet);
+    Items.unregisterSheet("core", globalThis.ItemSheet);
     Items.registerSheet("age-system", ageSystemSheetItem, {
         types: [
             "equipment",

--- a/age-system.js
+++ b/age-system.js
@@ -188,16 +188,24 @@ Hooks.once("init", function() {
         return outStr;
     });
 
-    Handlebars.registerHelper('effectModeName', function(modeNumber) {
-        const modeNames = [
-            "EFFECT.MODE_CUSTOM",
-            "EFFECT.MODE_MULTIPLY",
-            "EFFECT.MODE_ADD",
-            "EFFECT.MODE_DOWNGRADE",
-            "EFFECT.MODE_UPGRADE",
-            "EFFECT.MODE_OVERRIDE"
-        ];
-        return game.i18n.localize(modeNames[modeNumber]);
+    Handlebars.registerHelper('effectModeName', function(modeValue) {
+        // Handle both old numeric and new string type values
+        const modeNames = {
+            0: "EFFECT.MODE_CUSTOM",
+            1: "EFFECT.MODE_MULTIPLY",
+            2: "EFFECT.MODE_ADD",
+            3: "EFFECT.MODE_DOWNGRADE",
+            4: "EFFECT.MODE_UPGRADE",
+            5: "EFFECT.MODE_OVERRIDE",
+            "CUSTOM": "EFFECT.MODE_CUSTOM",
+            "MULTIPLY": "EFFECT.MODE_MULTIPLY",
+            "ADD": "EFFECT.MODE_ADD",
+            "DOWNGRADE": "EFFECT.MODE_DOWNGRADE",
+            "UPGRADE": "EFFECT.MODE_UPGRADE",
+            "OVERRIDE": "EFFECT.MODE_OVERRIDE"
+        };
+        const localizeKey = modeNames[modeValue] || "EFFECT.MODE_CUSTOM";
+        return game.i18n.localize(localizeKey);
     });
 
     // Handlebar to set dice icon based on numeric value

--- a/modules/advancement.js
+++ b/modules/advancement.js
@@ -627,7 +627,7 @@ export class AgeProgUI extends FormApplication { // Realizar adequação para le
     const helper = this.newLevel.helper.health; 
 		const roll = await new Roll(helper.formula).evaluate();
     helper.total = roll.total;
-		roll.toMessage({flavor: ageSystem.healthSys.healthName}, {rollMode: "public"});
+		roll.toMessage({flavor: ageSystem.healthSys.healthName}, {messageMode: "publicroll"});
     this.render(true);
   }
 

--- a/modules/age-chat.js
+++ b/modules/age-chat.js
@@ -32,24 +32,38 @@ export function addChatListeners(html) {
  * @param {object[]} options    The Array of Context Menu options
  * @returns {object[]}          The extended options Array including new context choices
  */
- export const addChatMessageContextOptions = function(html, options) {
+export const addChatMessageContextOptions = function(html, options) {
     let canApply = li => {
         const message = game.messages.get(li.dataset.messageId);
-        return message?.isRoll && message?.isContentVisible && (ageSystem.useTargeted ? game.user.targets.size : canvas.tokens?.controlled.length);
+        return message?.isRoll
+            && message?.isContentVisible
+            && (ageSystem.useTargeted
+                ? game.user.targets.size
+                : canvas.tokens?.controlled.length);
     };
+
     options.push(
-    {
-        name: game.i18n.localize("age-system.item.healing"),
-        icon: '<i class="fa fa-heartbeat" aria-hidden="true"></i>',
-        condition: canApply,
-        callback: li => applyChatCardDamage(li, {isHealing: true, isNewHP: false})
-    },
-    {
-        name: game.i18n.localize("age-system.applyDamage"),
-        icon: '<i class="fa fa-crosshairs" aria-hidden="true"></i>',
-        condition: canApply,
-        callback: li => applyChatCardDamage(li, {isDamage: true})
-    });
+        {
+            name: game.i18n.localize("age-system.item.healing"),
+            icon: '<i class="fa fa-heartbeat" aria-hidden="true"></i>',
+            condition: canApply,
+            onClick: (event, target) =>
+                applyChatCardDamage(target, {
+                    isHealing: true,
+                    isNewHP: false
+                })
+        },
+        {
+            name: game.i18n.localize("age-system.applyDamage"),
+            icon: '<i class="fa fa-crosshairs" aria-hidden="true"></i>',
+            condition: canApply,
+            onClick: (event, target) =>
+                applyChatCardDamage(target, {
+                    isDamage: true
+                })
+        }
+    );
+
     return options;
 };
 

--- a/modules/age-roller.js
+++ b/modules/age-roller.js
@@ -63,7 +63,7 @@ export class AgeRoller extends Application {
 		if (type === 'd666') formula += '1d6*100 + '
 		formula += '1d6*10 + 1d6'
 		let roll = await new Roll(formula).evaluate();
-		return roll.toMessage({flavor: type}, {rollMode: (ev.shiftKey || ev.type === "contextmenu") ? "selfroll" : ""});
+		return roll.toMessage({flavor: type}, {messageMode: (ev.shiftKey || ev.type === "contextmenu") ? "selfroll" : ""});
 	}
 
 	tokenBreather(ev) {
@@ -155,7 +155,7 @@ export class AgeRoller extends Application {
 	async _onRightClick(event) {
 		event.preventDefault();
 		let roll = await new Roll("1d6").evaluate();
-		return roll.toMessage({}, {rollMode: event.shiftKey ? "blindroll" : ""});
+		return roll.toMessage({}, {messageMode: event.shiftKey ? "blindroll" : ""});
 	}
 
 	_onResetPosition(event) {

--- a/modules/age-tracker.js
+++ b/modules/age-tracker.js
@@ -126,6 +126,6 @@ export class AgeTracker extends foundry.applications.api.HandlebarsApplicationMi
 		const compType = game.i18n.localize(`SETTINGS.comp${game.settings.get("age-system", "complication")}`);
 		const flavor = game.i18n.format("age-system.chatCard.compRoll", {compType});
 		let compRoll = new Roll("1d6");
-		return compRoll.toMessage({flavor, rollMode: "selfroll", whisper: [game.user.id]});
+		return compRoll.toMessage({flavor, messageMode: "selfroll", whisper: [game.user.id]});
 	}
 }

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -105,7 +105,10 @@ export class ageSystemActor extends Actor {
         changes.push(...effect.changes.map(change => {
             const c = foundry.utils.deepClone(change);
             c.effect = effect;
-            c.priority = c.priority ?? (c.mode * 10);
+            // Convert string type to numeric for priority calculation (Foundry v14+)
+            const typeMap = { CUSTOM: 0, MULTIPLY: 1, ADD: 2, DOWNGRADE: 3, UPGRADE: 4, OVERRIDE: 5 };
+            const modeNum = typeof c.type === 'string' ? (typeMap[c.type] ?? 0) : (c.type ?? 0);
+            c.priority = c.priority ?? (modeNum * 10);
             return c;
         }));
         for ( const statusId of effect.statuses ) this.statuses.add(statusId);

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -903,7 +903,7 @@ export class ageSystemActor extends Actor {
         if (options.abl !== 'no-abl') formula += ` + ${Math.max(charData.abilities[options.abl].total, 0)}`;
         if (options.addLevel) formula += ageSystem.healthSys.useInjury ? ` + ${Math.floor(charData.level/4)}` : ` + ${charData.level}`;
         let roll = new Roll(formula, this.actorRollData()).evaluateSync();
-		roll.toMessage({flavor: `${this.name} | ${game.i18n.localize("age-system.breather")}`}, {rollMode});
+		roll.toMessage({flavor: `${this.name} | ${game.i18n.localize("age-system.breather")}`}, {messageMode: rollMode});
         if (options.autoApply) return ageSystem.healthSys.useInjury ? this.healMarks(roll.total) : this.applyHPchange(roll.total, {isHealing: true, isNewHP: false});
     }
 

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -932,7 +932,7 @@ export class ageSystemActor extends Actor {
                 default: "normal",
                 close: () => resolve({cancelled: true}),
             }
-            new Dialog(dialogData, null).render(true);
+            new Dialog(dialogData).render(true);
         });
     }
 

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -128,7 +128,7 @@ export class ageSystemActor extends Actor {
         // Apply all changes
         for ( const change of changes ) {
         if ( !change.key ) continue;
-        const changes = change.effect.apply(this, change);
+        const changes = change.effect.applyChange(this, change);
         Object.assign(overrides, changes);
         }
 
@@ -142,7 +142,7 @@ export class ageSystemActor extends Actor {
         // Apply all changes
         for ( let change of changes ) {
             if ( !change.key || !paths.includes(change.key)) continue;
-            const changes = change.effect.apply(this, change);
+            const changes = change.effect.applyChange(this, change);
             Object.assign(dOverrides, changes);
         }
     

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -911,7 +911,7 @@ export class ageSystemActor extends Actor {
         const template = "/systems/age-system/templates/rolls/breather-settings.hbs";
         const html = await foundry.applications.handlebars.renderTemplate(template, data);
         return new Promise(resolve => {
-            const data = {
+            const dialogData = {
                 title: game.i18n.localize("age-system.breather"),
                 content: html,
                 buttons: {
@@ -932,7 +932,7 @@ export class ageSystemActor extends Actor {
                 default: "normal",
                 close: () => resolve({cancelled: true}),
             }
-            new Dialog(data, null).render(true);
+            new Dialog(dialogData, null).render(true);
         });
     }
 

--- a/modules/ageSystemActor.js
+++ b/modules/ageSystemActor.js
@@ -128,7 +128,7 @@ export class ageSystemActor extends Actor {
         // Apply all changes
         for ( const change of changes ) {
         if ( !change.key ) continue;
-        const changes = change.effect.applyChange(this, change);
+        const changes = change.effect.constructor.applyChange(this, change);
         Object.assign(overrides, changes);
         }
 
@@ -142,7 +142,7 @@ export class ageSystemActor extends Actor {
         // Apply all changes
         for ( let change of changes ) {
             if ( !change.key || !paths.includes(change.key)) continue;
-            const changes = change.effect.applyChange(this, change);
+            const changes = change.effect.constructor.applyChange(this, change);
             Object.assign(dOverrides, changes);
         }
     

--- a/modules/ageSystemItem.js
+++ b/modules/ageSystemItem.js
@@ -720,7 +720,7 @@ export class ageSystemItem extends Item {
             chatData.style = CONST.CHAT_MESSAGE_STYLES.WHISPER;
             chatData.whisper = [game.user.id];
         } else {
-            ChatMessage.applyRollMode(chatData, rollMode);
+            ChatMessage.applyMode(chatData, foundry.dice.Roll._mapLegacyRollMode(rollMode))
         }
         return ChatMessage.create(chatData);
     };

--- a/modules/apply-damage.js
+++ b/modules/apply-damage.js
@@ -428,6 +428,6 @@ export async function summaryToChat(summary, useInjury, isHealing = false) {
     content: await foundry.applications.handlebars.renderTemplate(chatTemplate, templateData),
     style: CONST.CHAT_MESSAGE_STYLES.OOC,
   }
-  await ChatMessage.applyRollMode(chatData, 'gmroll');
+  await ChatMessage.applyMode(chatData, foundry.dice.Roll._mapLegacyRollMode('gmroll'));
   return ChatMessage.create(chatData);
 }

--- a/modules/conditions-workshop.js
+++ b/modules/conditions-workshop.js
@@ -282,8 +282,8 @@ export default class ConditionsWorkshop extends Application {
         condition.changes[changeId].key = newValue;
         break;
       
-      case 'change-mode':
-        condition.changes[changeId].mode = newValue;
+      case 'change-type':
+        condition.changes[changeId].type = newValue;
         break;
 
       case 'change-value':

--- a/modules/dice.js
+++ b/modules/dice.js
@@ -516,7 +516,7 @@ async function getAgeRollOptions(itemRolled, data = {}) {
             default: "normal",
             close: () => resolve({cancelled: true}),
         }
-        new Dialog(dialogData, null).render(true);
+        new Dialog(dialogData).render(true);
     });
 };
 
@@ -553,7 +553,7 @@ async function getDamageRollOptions(addFocus, stuntDmg, data = {}) {
             default: "normal",
             close: () => resolve({cancelled: true}),
         }
-        new Dialog(dialogData, null).render(true);
+        new Dialog(dialogData).render(true);
     });
 };
 

--- a/modules/dice.js
+++ b/modules/dice.js
@@ -446,7 +446,8 @@ export async function ageRollCheck({event = null, actor = null, abl = null, item
     };
 
     if (!chatData.sound) chatData.sound = CONFIG.sounds.dice;
-    return ChatMessage.create(chatData, {messageMode: rollMode});
+    ChatMessage.applyMode(chatData, foundry.dice.Roll._mapLegacyRollMode(rollMode));
+    return ChatMessage.create(chatData);
 };
 
 // Check if the roll has Weapon Group penalty

--- a/modules/dice.js
+++ b/modules/dice.js
@@ -446,7 +446,7 @@ export async function ageRollCheck({event = null, actor = null, abl = null, item
     };
 
     if (!chatData.sound) chatData.sound = CONFIG.sounds.dice;
-    return ChatMessage.create(chatData, {rollMode});
+    return ChatMessage.create(chatData, {messageMode: rollMode});
 };
 
 // Check if the roll has Weapon Group penalty
@@ -720,7 +720,7 @@ export async function vehicleDamage ({
 
     let dmgRoll = await new Roll(damageFormula, rollData).evaluate();
 
-    return dmgRoll.toMessage(messageData, {whisper: audience, rollMode: isBlind});
+    return dmgRoll.toMessage(messageData, {whisper: audience, messageMode: isBlind});
 
 }
 

--- a/modules/dice.js
+++ b/modules/dice.js
@@ -495,7 +495,7 @@ async function getAgeRollOptions(itemRolled, data = {}) {
     });
 
     return new Promise(resolve => {
-        const data = {
+        const dialogData = {
             title: game.i18n.localize("age-system.ageRollOptions"),
             content: html,
             buttons: {
@@ -516,7 +516,7 @@ async function getAgeRollOptions(itemRolled, data = {}) {
             default: "normal",
             close: () => resolve({cancelled: true}),
         }
-        new Dialog(data, null).render(true);
+        new Dialog(dialogData, null).render(true);
     });
 };
 
@@ -532,7 +532,7 @@ async function getDamageRollOptions(addFocus, stuntDmg, data = {}) {
     });
 
     return new Promise(resolve => {
-        const data = {
+        const dialogData = {
             title: game.i18n.localize("age-system.damageOptions"),
             content: html,
             buttons: {
@@ -553,7 +553,7 @@ async function getDamageRollOptions(addFocus, stuntDmg, data = {}) {
             default: "normal",
             close: () => resolve({cancelled: true}),
         }
-        new Dialog(data, null).render(true);
+        new Dialog(dialogData, null).render(true);
     });
 };
 

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -632,7 +632,7 @@ export async function updateFocusCompendia() {
 
   // Identify if Item Compendipia were added or deleted and warn user that new option will appear only after System Refresh (F5)
   // TODO - add dynamic choices for System Setting
-  if (!foundry.utils.objectsEqual(list, actualChoices)) {
+  if (!foundry.utils.equals(list, actualChoices)) {
     const newPacks = [];
     const oldPacks = [];
     for (const p in actualChoices) if (!list[p]) oldPacks.push(actualChoices[p]);

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -228,7 +228,7 @@ export const registerSystemSettings = async function() {
       ageSystem.healthSys.mode = game.settings.get("age-system", "gameMode"),
       [...game.actors.contents, ...Object.values(game.actors.tokens)]
         .filter((o) => {
-          return o.data.type === "char";
+          return o.type === "char";
         })
         .forEach((o) => {
           o.prepareData();

--- a/modules/setup.js
+++ b/modules/setup.js
@@ -140,7 +140,7 @@ export function prepAdvSetup (html) {
  * @param {jQuery Object} html jQuery object whithin sheet
  * @param {object} data data used to render sheet
  */
-export async function prepSheet (sheet, html, doc) {
+export async function prepSheet (sheet, html, data) {
     // Add color customization
     const base = html.closest(`.age-system.sheet`);
     const classes = [];
@@ -156,7 +156,7 @@ export async function prepSheet (sheet, html, doc) {
     base[0].classList.add(`colorset-${ageSystem.colorScheme}`);
     
     // Add minimum width for Vehicle and Spaceship sheets
-    if(['vehicle', 'spaceship'].includes(doc.data.type)) base.css("min-width", "665px");
+    if(['vehicle', 'spaceship'].includes(sheet.object.type)) base.css("min-width", "665px");
 
     // Enrich HMTL text
     enrichTinyMCE(`div.editor-content`);

--- a/modules/sheets/ageSystemSheetCharStatBlock.js
+++ b/modules/sheets/ageSystemSheetCharStatBlock.js
@@ -32,7 +32,7 @@ export default class ageSystemSheetCharStatBlock extends ageSystemSheetCharacter
         $(`a.editor-edit`).hide(); // Used this code to remove the possibility to edit Powers on Stat Block view
         super.activateListeners(html);
         if (this.isEditable) {
-            new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-edit", this.itemContextMenu);
+            new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-edit", this.itemContextMenu, {jQuery: false});
         }
     };
 }

--- a/modules/sheets/ageSystemSheetCharStatBlock.js
+++ b/modules/sheets/ageSystemSheetCharStatBlock.js
@@ -32,7 +32,7 @@ export default class ageSystemSheetCharStatBlock extends ageSystemSheetCharacter
         $(`a.editor-edit`).hide(); // Used this code to remove the possibility to edit Powers on Stat Block view
         super.activateListeners(html);
         if (this.isEditable) {
-            new ContextMenu(html, ".item-edit", this.itemContextMenu);
+            new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-edit", this.itemContextMenu);
         }
     };
 }

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -232,8 +232,8 @@ export default class ageSystemSheetCharacter extends ActorSheet {
         };
 
         if (this.actor.isOwner) {
-            new foundry.applications.ux.ContextMenu.implementation(html, ".focus-options", this.focusContextMenu, {jQuery: false});
-            new foundry.applications.ux.ContextMenu.implementation(html, ".item-card .main-data img", this.itemContextMenu, {jQuery: false});
+            new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu, {jQuery: false});
+            new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-card .main-data img", this.itemContextMenu, {jQuery: false});
             html.find(".item-equip").click(this._onItemActivate.bind(this));
             html.find(".item-card .main-data").click(this._onItemEdit.bind(this));
             html.find(".defend-maneuver").change(this._onDefendSelect.bind(this));

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -235,7 +235,7 @@ export default class ageSystemSheetCharacter extends ActorSheet {
             new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu, {jQuery: false});
             new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-card .main-data img", this.itemContextMenu, {jQuery: false});
             html.find(".item-equip").click(this._onItemActivate.bind(this));
-            html.find(".item-card .main-data").click(this._onItemEdit.bind(this));
+            html[0].find(".item-card .main-data").click(this._onItemEdit.bind(this));
             html.find(".defend-maneuver").change(this._onDefendSelect.bind(this));
             html.find(".guardup-maneuver").change(this._onGuardUpSelect.bind(this));
             html.find(".conditions .item-name").click(this._onChangeCondition.bind(this));

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -434,7 +434,7 @@ export default class ageSystemSheetCharacter extends ActorSheet {
 
     async _onAddEffect(event) {
         const newEffect = {
-            name: game.i18n.localize("age-system.item.newItem"),
+            label: game.i18n.localize("age-system.item.newItem"),
             origin: this.actor.uuid,
             img: `icons/svg/aura.svg`,
             disabled: true,
@@ -580,7 +580,7 @@ export default class ageSystemSheetCharacter extends ActorSheet {
 
     focusContextMenu = [
         {
-            name: game.i18n.localize("age-system.ageRollOptions"),
+            label: game.i18n.localize("age-system.ageRollOptions"),
             icon: '<i class="fas fa-dice"></i>',
             callback: e => {
                 const focus = this._selectItemFromHTML(e);
@@ -589,12 +589,12 @@ export default class ageSystemSheetCharacter extends ActorSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.chatCard.roll"),
+            label: game.i18n.localize("age-system.chatCard.roll"),
             icon: '<i class="far fa-eye"></i>',
             callback: e => this._selectItemFromHTML(e).showItem(e.shiftKey)
         },
         {
-            name: game.i18n.localize("age-system.settings.changeRollContext"),
+            label: game.i18n.localize("age-system.settings.changeRollContext"),
             icon: '<i class="fas fa-exchange-alt"></i>',
             // TODO - try to add the Shift + Click rolling to GM inside this callback
             callback: e => {
@@ -604,12 +604,12 @@ export default class ageSystemSheetCharacter extends ActorSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.settings.edit"),
+            label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
             callback: e => this._selectItemFromHTML(e).sheet.render(true)
         },
         {
-            name: game.i18n.localize("age-system.settings.delete"),
+            label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
             callback: e => this._selectItemFromHTML(e).delete()
         }
@@ -617,17 +617,17 @@ export default class ageSystemSheetCharacter extends ActorSheet {
 
     itemContextMenu = [
         {
-            name: game.i18n.localize("age-system.showOnChat"),
+            label: game.i18n.localize("age-system.showOnChat"),
             icon: '<i class="far fa-eye"></i>',
             callback: e => this._selectItemFromHTML(e).showItem(e.shiftKey)
         },
         {
-            name: game.i18n.localize("age-system.settings.edit"),
+            label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
             callback: e => this._selectItemFromHTML(e).sheet.render(true)
         },
         {
-            name: game.i18n.localize("age-system.settings.delete"),
+            label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
             callback: e => this._selectItemFromHTML(e).delete()
         }

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -582,36 +582,54 @@ export default class ageSystemSheetCharacter extends ActorSheet {
         {
             label: game.i18n.localize("age-system.ageRollOptions"),
             icon: '<i class="fas fa-dice"></i>',
-            callback: e => {
-                const focus = this._selectItemFromHTML(e);
-                const ev = new MouseEvent('click', {altKey: true});
+            onClick: (event, target) => {
+                const focus = this._selectItemFromHTML(target);
+                const ev = new MouseEvent("click", { altKey: true });
                 focus.roll(ev);
             }
         },
         {
             label: game.i18n.localize("age-system.chatCard.roll"),
             icon: '<i class="far fa-eye"></i>',
-            callback: e => this._selectItemFromHTML(e).showItem(e.shiftKey)
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).showItem(event.shiftKey);
+            }
         },
         {
             label: game.i18n.localize("age-system.settings.changeRollContext"),
             icon: '<i class="fas fa-exchange-alt"></i>',
-            // TODO - try to add the Shift + Click rolling to GM inside this callback
-            callback: e => {
-                const focus = this._selectItemFromHTML(e);
-                const ev = new MouseEvent('click', {});
-                Dice.ageRollCheck({event: ev, itemRolled: focus, actor: this.actor, selectAbl: true, rollType: ageSystem.ROLL_TYPE.FOCUS});
+            onClick: (event, target) => {
+                const focus = this._selectItemFromHTML(target);
+
+                const ev = new MouseEvent("click", {
+                    shiftKey: event.shiftKey,
+                    ctrlKey: event.ctrlKey,
+                    altKey: event.altKey,
+                    metaKey: event.metaKey
+                });
+
+                Dice.ageRollCheck({
+                    event: ev,
+                    itemRolled: focus,
+                    actor: this.actor,
+                    selectAbl: true,
+                    rollType: ageSystem.ROLL_TYPE.FOCUS
+                });
             }
         },
         {
             label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
-            callback: e => this._selectItemFromHTML(e).sheet.render(true)
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).sheet.render(true);
+            }
         },
         {
             label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
-            callback: e => this._selectItemFromHTML(e).delete()
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).delete();
+            }
         }
     ];
 
@@ -619,17 +637,23 @@ export default class ageSystemSheetCharacter extends ActorSheet {
         {
             label: game.i18n.localize("age-system.showOnChat"),
             icon: '<i class="far fa-eye"></i>',
-            callback: e => this._selectItemFromHTML(e).showItem(e.shiftKey)
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).showItem(event.shiftKey);
+            }
         },
         {
             label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
-            callback: e => this._selectItemFromHTML(e).sheet.render(true)
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).sheet.render(true);
+            }
         },
         {
             label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
-            callback: e => this._selectItemFromHTML(e).delete()
+            onClick: (event, target) => {
+                this._selectItemFromHTML(target).delete();
+            }
         }
     ];
 

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -179,7 +179,7 @@ export default class ageSystemSheetCharacter extends ActorSheet {
             })
         }    
         if (this.isEditable) {
-            new foundry.applications.ux.ContextMenu.implementation(html, ".main-data", this.itemContextMenu, {jQuery: false});
+            new foundry.applications.ux.ContextMenu.implementation(html[0], ".main-data", this.itemContextMenu, {jQuery: false});
             html.find(".item-edit").click(this._onItemEdit.bind(this));
             html.find(".item-delete").click(this._onItemDelete.bind(this));
             html.find(".last-up").change(this._onLastUpSelect.bind(this));

--- a/modules/sheets/ageSystemSheetCharacter.js
+++ b/modules/sheets/ageSystemSheetCharacter.js
@@ -235,7 +235,7 @@ export default class ageSystemSheetCharacter extends ActorSheet {
             new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu, {jQuery: false});
             new foundry.applications.ux.ContextMenu.implementation(html[0], ".item-card .main-data img", this.itemContextMenu, {jQuery: false});
             html.find(".item-equip").click(this._onItemActivate.bind(this));
-            html[0].find(".item-card .main-data").click(this._onItemEdit.bind(this));
+            html.find(".item-card .main-data").click(this._onItemEdit.bind(this));
             html.find(".defend-maneuver").change(this._onDefendSelect.bind(this));
             html.find(".guardup-maneuver").change(this._onGuardUpSelect.bind(this));
             html.find(".conditions .item-name").click(this._onChangeCondition.bind(this));

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -136,7 +136,7 @@ export default class ageSystemItemSheet extends ItemSheet {
 
         // Check if Use Fatigue setting is TRUE
         data.fatigueSet = game.settings.get("age-system", "useFatigue");
-        data.system = data.data.system;
+        data.system = this.item.system;
 
         // If it is a Talent, check if it uses expanded talent degrees
         if(this.item.type === "talent") {

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -281,16 +281,16 @@ export default class ageSystemItemSheet extends ItemSheet {
         {
             label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
-            callback: e => {
-                const data = e[0].dataset;
+            onClick: (event, target) => {
+                const data = target.dataset;
                 this.object._onChangeAdvancement(data, 'edit');
             }
         },
         {
             label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
-            callback: e => {
-                const data = e[0].dataset;
+            onClick: (event, target) => {
+                const data = target.dataset;
                 this.object._onChangeAdvancement(data, 'remove');
             }
         }

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -3,7 +3,7 @@ import { modifiersList, sortObjArrayByName } from "../setup.js";
 import { focusList } from "../settings.js";
 import {AdvancementAdd} from "../advancement.js";
 
-export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
+export default class ageSystemItemSheet extends ItemSheet {
     constructor(...args) {
         super(...args);
     

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -171,7 +171,7 @@ export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
 
         // Actions by sheet owner only
         if (this.item.isOwner) {
-            if (this.item.type === "class") new foundry.applications.ux.ContextMenu.implementation(html[0], ".advance", this.advContextMenu);
+            if (this.item.type === "class") new foundry.applications.ux.ContextMenu.implementation(html[0], ".advance", this.advContextMenu, {jQuery: false});
         };
 
         // Add class to TinyMCE

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -96,7 +96,7 @@ export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
                 const feat = data.config.featuresType[f];
                 data.config.featuresTypeLocal.push({
                     key: feat,
-                    name: game.i18n.localize(`age-system.spaceship.${feat}`)
+                    label: game.i18n.localize(`age-system.spaceship.${feat}`)
                 });
             }
             data.config.featuresTypeLocal = sortObjArrayByName(data.config.featuresTypeLocal, "name");
@@ -279,7 +279,7 @@ export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
 
     advContextMenu = [
         {
-            name: game.i18n.localize("age-system.settings.edit"),
+            label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
             callback: e => {
                 const data = e[0].dataset;
@@ -287,7 +287,7 @@ export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.settings.delete"),
+            label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
             callback: e => {
                 const data = e[0].dataset;

--- a/modules/sheets/ageSystemSheetItem.js
+++ b/modules/sheets/ageSystemSheetItem.js
@@ -171,7 +171,7 @@ export default class ageSystemItemSheet extends foundry.appv1.sheets.ItemSheet {
 
         // Actions by sheet owner only
         if (this.item.isOwner) {
-            if (this.item.type === "class") new ContextMenu(html, ".advance", this.advContextMenu);
+            if (this.item.type === "class") new foundry.applications.ux.ContextMenu.implementation(html[0], ".advance", this.advContextMenu);
         };
 
         // Add class to TinyMCE

--- a/modules/sheets/ageSystemSheetOrg.js
+++ b/modules/sheets/ageSystemSheetOrg.js
@@ -53,7 +53,7 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
     };
     
     activateListeners(html) {
-        new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu);
+        new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu, {jQuery: false});
         super.activateListeners(html);
 
         if (this.actor.isOwner || this.observerRoll) {

--- a/modules/sheets/ageSystemSheetOrg.js
+++ b/modules/sheets/ageSystemSheetOrg.js
@@ -119,42 +119,48 @@ export default class ageSystemSheetOrg extends ActorSheet {
         {
             label: game.i18n.localize("age-system.ageRollOptions"),
             icon: '<i class="fas fa-dice"></i>',
-            callback: e => {
-                const focus = this.actor.items.get(e.data("item-id"));
-                const ev = new MouseEvent('click', {altKey: true});
+            onClick: (event, target) => {
+                const focus = this.actor.items.get(target.dataset.itemId);
+                const ev = new MouseEvent('click', { altKey: true });
                 focus.roll(ev);
             }
         },
         {
             label: game.i18n.localize("age-system.chatCard.roll"),
             icon: '<i class="far fa-eye"></i>',
-            callback: e => {
-                const i = this.actor.items.get(e.data("item-id")).showItem(e.shiftKey);
+            onClick: (event, target) => {
+                this.actor.items.get(target.dataset.itemId).showItem(event.shiftKey);
             }
         },
         {
             label: game.i18n.localize("age-system.settings.changeRollContext"),
             icon: '<i class="fas fa-exchange-alt"></i>',
             // TODO - try to add the Shift + Click rolling to GM inside this callback
-            callback: e => {
-                const focus = this.actor.items.get(e.data("item-id"));
-                const ev = new MouseEvent('click', {});
-                Dice.ageRollCheck({event: ev, itemRolled: focus, actor: this.actor, selectAbl: true, rollType: ageSystem.ROLL_TYPE.FOCUS});
+            onClick: (event, target) => {
+                const focus = this.actor.items.get(target.dataset.itemId);
+                const ev = new MouseEvent('click');
+                Dice.ageRollCheck({
+                    event: ev,
+                    itemRolled: focus,
+                    actor: this.actor,
+                    selectAbl: true,
+                    rollType: ageSystem.ROLL_TYPE.FOCUS
+                });
             }
         },
         {
             label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
-            callback: e => {
-                const item = this.actor.items.get(e.data("item-id"));
+            onClick: (event, target) => {
+                const item = this.actor.items.get(target.dataset.itemId);
                 item.sheet.render(true);
             }
         },
         {
             label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
-            callback: e => {
-                const i = this.actor.items.get(e.data("item-id")).delete();
+            onClick: (event, target) => {
+                this.actor.items.get(target.dataset.itemId)?.delete();
             }
         }
     ];

--- a/modules/sheets/ageSystemSheetOrg.js
+++ b/modules/sheets/ageSystemSheetOrg.js
@@ -53,7 +53,7 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
     };
     
     activateListeners(html) {
-        new ContextMenu(html, ".focus-options", this.focusContextMenu);
+        new foundry.applications.ux.ContextMenu.implementation(html[0], ".focus-options", this.focusContextMenu);
         super.activateListeners(html);
 
         if (this.actor.isOwner || this.observerRoll) {

--- a/modules/sheets/ageSystemSheetOrg.js
+++ b/modules/sheets/ageSystemSheetOrg.js
@@ -3,7 +3,7 @@ import {ageSystem} from "../config.js";
 import { sortObjArrayByName } from "../setup.js";
 import {newItemData} from "./helper.js";
 
-export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
+export default class ageSystemSheetOrg extends ActorSheet {
     
     static get defaultOptions() {
         return foundry.utils.mergeObject(super.defaultOptions, {

--- a/modules/sheets/ageSystemSheetOrg.js
+++ b/modules/sheets/ageSystemSheetOrg.js
@@ -117,7 +117,7 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
 
     focusContextMenu = [
         {
-            name: game.i18n.localize("age-system.ageRollOptions"),
+            label: game.i18n.localize("age-system.ageRollOptions"),
             icon: '<i class="fas fa-dice"></i>',
             callback: e => {
                 const focus = this.actor.items.get(e.data("item-id"));
@@ -126,14 +126,14 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.chatCard.roll"),
+            label: game.i18n.localize("age-system.chatCard.roll"),
             icon: '<i class="far fa-eye"></i>',
             callback: e => {
                 const i = this.actor.items.get(e.data("item-id")).showItem(e.shiftKey);
             }
         },
         {
-            name: game.i18n.localize("age-system.settings.changeRollContext"),
+            label: game.i18n.localize("age-system.settings.changeRollContext"),
             icon: '<i class="fas fa-exchange-alt"></i>',
             // TODO - try to add the Shift + Click rolling to GM inside this callback
             callback: e => {
@@ -143,7 +143,7 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.settings.edit"),
+            label: game.i18n.localize("age-system.settings.edit"),
             icon: '<i class="fas fa-edit"></i>',
             callback: e => {
                 const item = this.actor.items.get(e.data("item-id"));
@@ -151,7 +151,7 @@ export default class ageSystemSheetOrg extends foundry.appv1.sheets.ActorSheet {
             }
         },
         {
-            name: game.i18n.localize("age-system.settings.delete"),
+            label: game.i18n.localize("age-system.settings.delete"),
             icon: '<i class="fas fa-trash"></i>',
             callback: e => {
                 const i = this.actor.items.get(e.data("item-id")).delete();

--- a/modules/sheets/ageSystemSheetSpaceship.js
+++ b/modules/sheets/ageSystemSheetSpaceship.js
@@ -3,7 +3,7 @@ import {ageSystem} from "../config.js";
 import { sortObjArrayByName } from "../setup.js";
 import {dropChar, newItemData} from "./helper.js";
 
-export default class ageSpaceshipSheet extends foundry.appv1.sheets.ActorSheet {
+export default class ageSpaceshipSheet extends ActorSheet {
     
     static get defaultOptions() {
         return foundry.utils.mergeObject(super.defaultOptions, {

--- a/modules/sheets/ageSystemSheetVehicle.js
+++ b/modules/sheets/ageSystemSheetVehicle.js
@@ -3,7 +3,7 @@ import {ageSystem} from "../config.js";
 import { sortObjArrayByName } from "../setup.js";
 import {dropChar, newItemData} from "./helper.js";
 
-export default class ageSystemVehicleSheet extends foundry.appv1.sheets.ActorSheet {
+export default class ageSystemVehicleSheet extends ActorSheet {
     get isSynth() {
         return (this.token && !this.token.actorLink);
     }  

--- a/modules/sheets/ageSystemSheetVehicle.js
+++ b/modules/sheets/ageSystemSheetVehicle.js
@@ -142,7 +142,7 @@ export default class ageSystemVehicleSheet extends ActorSheet {
             if (speaker.token) user = game.actors.tokens[speaker.token];
             if (!user) user = game.actors.get(speaker.actor);
             conductorData = user;
-            if (user?.data.type != "char") return false;
+            if (user?.type != "char") return false;
         } else {
             conductorData = vehicleData.passengers.filter(p => p.isConductor === true)[0];
             if (conductorData.isToken) user = game.actors.tokens[conductorData.id];

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vkdolea/age-system.git"
+    "url": "git+https://github.com/remyke/age-system.git"
   },
-  "author": "vkdolea",
+  "author": "remyke",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/vkdolea/age-system/issues"
+    "url": "https://github.com/remyke/age-system/issues"
   },
-  "homepage": "https://github.com/vkdolea/age-system#readme",
+  "homepage": "https://github.com/remyke/age-system#readme",
   "devDependencies": {
     "gulp": "^5.0.1"
   }

--- a/system.json
+++ b/system.json
@@ -3,13 +3,13 @@
     "title": "AGE System (unofficial)",
     "description": "Unofficial AGE System implementation for most of AGE subsystems",
     "version": "4.0.4-compatibility14.1",
-    "download": "https://github.com/remyke/age-system/archive/4.0.4-compatibility14.1.zip",
+    "download": "https://github.com/remyke/age-system/archive/refs/heads/remyke_compability14.zip",
     "compatibility": {
         "minimum": "14.363",
         "verified": "14"
     },
     "url": "https://github.com/remyke/age-system",
-    "manifest": "https://raw.githubusercontent.com/remyke/age-system/4.0.4-compatibility14.1/system.json",
+    "manifest": "https://raw.githubusercontent.com/remyke/age-system/refs/heads/remyke_compability14/system.json",
     "media": [
         {
           "type": "cover",

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "AGE System (unofficial)",
     "description": "Unofficial AGE System implementation for most of AGE subsystems",
     "version": "4.0.4-compatibility14.1",
-    "download": "https://github.com/remyke/age-system/archive/4.0.4-compatibimity14.1.zip",
+    "download": "https://github.com/remyke/age-system/archive/4.0.4-compatibility14.1.zip",
     "compatibility": {
         "minimum": "14.363",
         "verified": "14"

--- a/system.json
+++ b/system.json
@@ -2,22 +2,14 @@
     "id": "age-system",
     "title": "AGE System (unofficial)",
     "description": "Unofficial AGE System implementation for most of AGE subsystems",
-    "version": "4.0.3",
-    "download": "https://github.com/vkdolea/age-system/archive/4.0.3.zip",
+    "version": "4.0.4-compatibility14.1",
+    "download": "https://github.com/remyke/age-system/archive/4.0.4-compatibimity14.1.zip",
     "compatibility": {
-        "minimum": "13.346",
-        "verified": "13"
+        "minimum": "14.363",
+        "verified": "14"
     },
-    "url": "https://github.com/vkdolea/age-system",
-    "manifest": "https://raw.githubusercontent.com/vkdolea/age-system/prep-release/system.json",
-    "authors": [
-		{
-			"name": "VK Dolea",
-			"discord": "vkdolea#7974",
-			"reddit":"u/vkdolea",
-			"ko-fi":"vkdolea"
-		}
-    ],
+    "url": "https://github.com/remyke/age-system",
+    "manifest": "https://raw.githubusercontent.com/remyke/age-system/4.0.4-compatibility14.1/system.json",
     "media": [
         {
           "type": "cover",
@@ -62,8 +54,8 @@
         "units": "yd"
     },
     "initiative": "3d6 + @initiative",
-    "bugs": "https://github.com/vkdolea/age-system/issues",
-    "readme": "https://github.com/vkdolea/age-system/blob/prep-release/README.md",
+    "bugs": "https://github.com/remyke/age-system/issues",
+    "readme": "https://github.com/remyke/age-system/blob/4.0.4-compatibility14.1/README.md",
     "flags": {
         "needsMigrationVersion": "0.12.5"
     }

--- a/system.json
+++ b/system.json
@@ -55,7 +55,7 @@
     },
     "initiative": "3d6 + @initiative",
     "bugs": "https://github.com/remyke/age-system/issues",
-    "readme": "https://github.com/remyke/age-system/blob/4.0.4-compatibility14.1/README.md",
+    "readme": "https://github.com/remyke/age-system/blob/remyke_compability14/README.md",
     "flags": {
         "needsMigrationVersion": "0.12.5"
     }

--- a/templates/advancement-setup.hbs
+++ b/templates/advancement-setup.hbs
@@ -36,7 +36,6 @@
             <div class="flexrow flex-align-baseline option">
                 <label for=""><strong>{{localize "age-system.level"}}</strong></label>
                 <select name="level" class="header-input">
-                    {{#select level}}
                     {{#each adv}}
                     {{#if levelarr(@index) level}}
                     <option value="{{levelarr @index}}" selected>{{levelarr @index}}</option>
@@ -54,7 +53,6 @@
                 <label for=""><strong>{{localize "age-system.itemProgression"}}</strong></label>
                 <div class="field-data flexrow flex-align-baseline">
                     <select name="tType" class="header-input">
-                        {{#select tType}}
                         {{#each traitArr as |tt|}}
                         {{#if (ne tt.key 'power')}}
                         {{#if eq tType tt.key}}

--- a/templates/advancement-setup.hbs
+++ b/templates/advancement-setup.hbs
@@ -37,13 +37,8 @@
                 <label for=""><strong>{{localize "age-system.level"}}</strong></label>
                 <select name="level" class="header-input">
                     {{#each adv}}
-                    {{#if levelarr(@index) level}}
-                    <option value="{{levelarr @index}}" selected>{{levelarr @index}}</option>
-                    {{else}}
-                    <option value="{{levelarr @index}}">{{levelarr @index}}</option>
-                    {{/if}}
+                    <option value="{{levelarr @index}}"{{#if (eq levelarr(@index) level)}} selected{{/if}}>{{levelarr @index}}</option>
                     {{/each}}
-                    {{/select}}
                 </select>
                 {{!-- <select name="level" class="header-input">
                     {{selectOptions advLabel}}
@@ -55,14 +50,9 @@
                     <select name="tType" class="header-input">
                         {{#each traitArr as |tt|}}
                         {{#if (ne tt.key 'power')}}
-                        {{#if eq tType tt.key}}
-                        <option value="{{tt.key}}" selected>{{tt.name}}</option>
-                        {{else}}
-                        <option value="{{tt.key}}">{{tt.name}}</option>
-                        {{/if}}
+                        <option value="{{tt.key}}"{{#if (eq tType tt.key)}} selected{{/if}}>{{tt.name}}</option>
                         {{/if}}
                         {{/each}}
-                        {{/select}}
                     </select>
                     <button class="addItemProg" type="button" style="flex: 0;">
                         {{localize "age-system.add"}}

--- a/templates/advancement-setup.hbs
+++ b/templates/advancement-setup.hbs
@@ -38,7 +38,11 @@
                 <select name="level" class="header-input">
                     {{#select level}}
                     {{#each adv}}
+                    {{#if levelarr(@index) level}}
+                    <option value="{{levelarr @index}}" selected>{{levelarr @index}}</option>
+                    {{else}}
                     <option value="{{levelarr @index}}">{{levelarr @index}}</option>
+                    {{/if}}
                     {{/each}}
                     {{/select}}
                 </select>
@@ -53,7 +57,11 @@
                         {{#select tType}}
                         {{#each traitArr as |tt|}}
                         {{#if (ne tt.key 'power')}}
+                        {{#if eq tType tt.key}}
+                        <option value="{{tt.key}}" selected>{{tt.name}}</option>
+                        {{else}}
                         <option value="{{tt.key}}">{{tt.name}}</option>
+                        {{/if}}
                         {{/if}}
                         {{/each}}
                         {{/select}}

--- a/templates/conditions-workshop.hbs
+++ b/templates/conditions-workshop.hbs
@@ -47,8 +47,8 @@
                                     <input type="text" class="user-entry" data-field="change-key" name="changes.{{i}}.key" value="{{change.key}}"/>
                                 </div>
                                 <div class="mode">
-                                    <select name="changes.{{i}}.mode" class="user-entry" data-field="change-mode" data-dtype="Number">
-                                        {{selectOptions ../../modes selected=change.mode }}
+                                    <select name="changes.{{i}}.type" class="user-entry" data-field="change-type">
+                                        {{selectOptions ../../modes selected=change.type }}
                                     </select>
                                 </div>
                                 <div class="value">

--- a/templates/partials/ability-focus-select.hbs
+++ b/templates/partials/ability-focus-select.hbs
@@ -2,12 +2,8 @@
     {{!-- Ability to activate item --}}
     <div class="flexcol minimum-length">
         <select name="system.useAbl" class="header-input">
-            {{#select system.useAbl}}
             <option value="no-abl">-</option>
-            {{#each config.abilities as |name type|}}
-            <option value="{{type}}">{{localize name}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions config.abilities selected=system.useAbl localize=true}}
         </select>
         <label class="label-under">{{localize "age-system.abl"}}</label>
     </div>

--- a/templates/partials/bonuses-sheet.hbs
+++ b/templates/partials/bonuses-sheet.hbs
@@ -7,12 +7,8 @@
     {{#each system.modifiers as |mod i|}}
     <li class="item-box flexrow feature-controls colorset-third-tier" data-mod-index="{{i}}">
         <select class="mod-type" name="system.modifiers.{{i}}.type">
-            {{#select mod.type}}
             <option value="">-</option>
-            {{#each ../modifiersList as |modType name|}}
-            <option value="{{name}}">{{modType}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions ../modifiersList selected=mod.type localize=true}}
         </select>
         <div class="mod-value">
             <input type="text" class="mod" name="system.modifiers.{{i}}.conditions.focus" value="{{mod.conditions.focus}}" placeholder="{{localize "age-system.focus"}}" {{#unless (or (eq mod.type "focus") (eq mod.type "focusPowerForce"))}}style="display: none"{{/unless}}/>

--- a/templates/partials/dmg-block-sheet.hbs
+++ b/templates/partials/dmg-block-sheet.hbs
@@ -30,8 +30,8 @@
                 {{else}}
                 <input type="number" name="system.nrDice" value="{{system.nrDice}}" data-dtype="Number" />
                 <select name="system.diceType" class="dice-size">
-                    <option value="6"{{#if "6" system.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d6"}}</option>
-                    <option value="3"{{#if "3" system.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d3"}}</option>
+                    <option value="6"{{#if (eq "6" system.diceType)}} selected{{/if}}>{{localize "age-system.settings.d6"}}</option>
+                    <option value="3"{{#if (eq "3" system.diceType)}} selected{{/if}}>{{localize "age-system.settings.d3"}}</option>
                 </select>
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <input type="number" name="system.extraValue" value="{{system.extraValue}}" data-dtype="Number" />
@@ -66,8 +66,8 @@
                 {{else}}
                 <input type="number" name="system.damageResisted.nrDice" value="{{system.damageResisted.nrDice}}" data-dtype="Number" />
                 <select name="system.damageResisted.diceType" class="dice-size">
-                    <option value="6"{{#if "6" system.damageResisted.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d6"}}</option>
-                    <option value="3"{{#if "3" system.damageResisted.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d3"}}</option>
+                    <option value="6"{{#if (eq "6" system.damageResisted.diceType)}} selected{{/if}}>{{localize "age-system.settings.d6"}}</option>
+                    <option value="3"{{#if (eq "3" system.damageResisted.diceType)}} selected{{/if}}>{{localize "age-system.settings.d3"}}</option>
                 </select>
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <input type="number" name="system.damageResisted.extraValue" value="{{system.damageResisted.extraValue}}" data-dtype="Number" />

--- a/templates/partials/dmg-block-sheet.hbs
+++ b/templates/partials/dmg-block-sheet.hbs
@@ -40,12 +40,8 @@
                 {{/if}}
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <select name="system.dmgAbl">
-                    {{#select system.dmgAbl}}
                     <option value="no-abl">—</option>
-                    {{#each config.abilities as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.abilities selected=system.dmgAbl localize=true}}
                 </select>
             </div>
         </div>
@@ -53,19 +49,11 @@
         <div class="flexrow">
             {{#if config.healthSys.useBallistic}}
             <select name="system.dmgType">
-                {{#select system.dmgType}}
-                {{#each config.damageType as |name type|}}
-                <option value="{{type}}">{{localize name}}</option>
-                {{/each}}
-                {{/select}}
+                {{selectOptions config.damageType selected=system.dmgType localize=true}}
             </select>
             {{/if}}
             <select name="system.dmgSource">
-                {{#select system.dmgSource}}
-                {{#each config.damageSource as |name source|}}
-                <option value="{{source}}">{{localize name}}</option>
-                {{/each}}
-                {{/select}}
+                {{selectOptions config.damageSource selected=system.dmgSource localize=true}}
             </select>
         </div>
         {{/if}}
@@ -90,12 +78,8 @@
                 {{/if}}
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <select name="system.damageResisted.dmgAbl">
-                    {{#select system.damageResisted.dmgAbl}}
                     <option value="no-abl">—</option>
-                    {{#each config.abilities as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.abilities selected=system.damageResisted.dmgAbl localize=true}}
                 </select>
             </div>
         </div>

--- a/templates/partials/dmg-block-sheet.hbs
+++ b/templates/partials/dmg-block-sheet.hbs
@@ -30,10 +30,8 @@
                 {{else}}
                 <input type="number" name="system.nrDice" value="{{system.nrDice}}" data-dtype="Number" />
                 <select name="system.diceType" class="dice-size">
-                    {{#select system.diceType}}
-                    <option value="6">{{localize "age-system.settings.d6"}}</option>
-                    <option value="3">{{localize "age-system.settings.d3"}}</option>
-                    {{/select}}
+                    <option value="6"{{#if "6" system.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d6"}}</option>
+                    <option value="3"{{#if "3" system.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d3"}}</option>
                 </select>
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <input type="number" name="system.extraValue" value="{{system.extraValue}}" data-dtype="Number" />
@@ -68,10 +66,8 @@
                 {{else}}
                 <input type="number" name="system.damageResisted.nrDice" value="{{system.damageResisted.nrDice}}" data-dtype="Number" />
                 <select name="system.damageResisted.diceType" class="dice-size">
-                    {{#select system.damageResisted.diceType}}
-                    <option value="6">{{localize "age-system.settings.d6"}}</option>
-                    <option value="3">{{localize "age-system.settings.d3"}}</option>
-                    {{/select}}
+                    <option value="6"{{#if "6" system.damageResisted.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d6"}}</option>
+                    <option value="3"{{#if "3" system.damageResisted.diceType}}" selected"{{/if}}>{{localize "age-system.settings.d3"}}</option>
                 </select>
                 <span>{{localize "age-system.settings.plusSign"}}</span>
                 <input type="number" name="system.damageResisted.extraValue" value="{{system.damageResisted.extraValue}}" data-dtype="Number" />

--- a/templates/partials/item-options-sheet.hbs
+++ b/templates/partials/item-options-sheet.hbs
@@ -32,34 +32,22 @@
             <li class="colorset-third-tier flexrow">
                 <label for="">{{localize "age-system.abl"}}</label>
                 <select name="system.dmgAbl">
-                    {{#select system.dmgAbl}}
                     <option value="no-abl">—</option>
-                    {{#each config.abilities as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.abilities selected=system.dmgAbl localize=true}}
                 </select>
             </li>
             {{#if config.healthSys.useBallistic}}
             <li class="colorset-third-tier flexrow">
                 <label class="colorset-third-tier">{{localize "age-system.type"}}</label>
                 <select name="system.dmgType">
-                    {{#select system.dmgType}}
-                    {{#each config.damageType as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.damageType selected=system.dmgType localize=true}}
                 </select>
             </li>
             {{/if}}
             <li class="colorset-third-tier flexrow">
                 <label class="colorset-third-tier">{{localize "age-system.source"}}</label>
                 <select name="system.dmgSource">
-                    {{#select system.dmgSource}}
-                    {{#each config.damageSource as |name source|}}
-                    <option value="{{source}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.damageSource selected=system.dmgSource localize=true}}
                 </select>
             </li>
         </ul>

--- a/templates/quick-settings.hbs
+++ b/templates/quick-settings.hbs
@@ -17,10 +17,13 @@
         <div class="form-fields">
             {{#if isSelect}}
             <select name="{{key}}">
-                {{#select value}}
                 {{#each choices as |name type|}}
                 {{#unless (and (eq ../key 'gameMode') (eq type 'none'))}}
+                {{#if eq value type}}
+                <option value="{{type}}" selected>{{localize name}}</option>
+                {{else}}
                 <option value="{{type}}">{{localize name}}</option>
+                {{/if}}
                 {{/unless}}
                 {{/each}}
                 {{/select}}

--- a/templates/quick-settings.hbs
+++ b/templates/quick-settings.hbs
@@ -19,14 +19,9 @@
             <select name="{{key}}">
                 {{#each choices as |name type|}}
                 {{#unless (and (eq ../key 'gameMode') (eq type 'none'))}}
-                {{#if eq value type}}
-                <option value="{{type}}" selected>{{localize name}}</option>
-                {{else}}
-                <option value="{{type}}">{{localize name}}</option>
-                {{/if}}
+                <option value="{{type}}"{{#if (eq value type)}} selected{{/if}}>{{localize name}}</option>
                 {{/unless}}
                 {{/each}}
-                {{/select}}
             </select>
             {{else}}
             {{#if (eq type 'Boolean')}}

--- a/templates/rolls/age-roll-settings.hbs
+++ b/templates/rolls/age-roll-settings.hbs
@@ -3,12 +3,8 @@
     <div class="form-group">
         <label>Select Ability</label>
         <select name="selectedAbl">
-            {{#select selectedAbl}}
             <option value="no-abl">—</option>
-            {{#each abilities as |name key|}}
-            <option value="{{key}}">{{name}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions abilities selected=system.selectedAbl localize=true}}
         </select>
     </div>
     {{/if}}

--- a/templates/rolls/breather-settings.hbs
+++ b/templates/rolls/breather-settings.hbs
@@ -7,12 +7,8 @@
     <div class="form-group">
         <label>{{localize "age-system.ablSelect"}}</label>
         <select name="abl">
-            {{#select abl}}
             <option value="no-abl">—</option>
-            {{#each abilities as |name key|}}
-            <option value="{{key}}">{{name}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions abilities selected=abl localize=true}}
         </select>
     </div>
 

--- a/templates/rolls/dmg-roll-settings.hbs
+++ b/templates/rolls/dmg-roll-settings.hbs
@@ -12,26 +12,26 @@
     <div class="form-group">
         <label>{{localize "age-system.setStuntDmg"}}</label>
         <select name="setStuntDamage">
-            <option value="0"{{#if (eq "0" data.diceType)}} selected{{/1f}}>-</option>
-            <option value="1"{{#if (eq "1" data.diceType)}} selected{{/1f}}>1{{localize "age-system.settings.d6"}}</option>
-            <option value="2"{{#if (eq "2" data.diceType)}} selected{{/1f}}>2{{localize "age-system.settings.d6"}}</option>
+            <option value="0"{{#if (eq "0" data.diceType)}} selected{{/if}}>-</option>
+            <option value="1"{{#if (eq "1" data.diceType)}} selected{{/if}}>1{{localize "age-system.settings.d6"}}</option>
+            <option value="2"{{#if (eq "2" data.diceType)}} selected{{/if}}>2{{localize "age-system.settings.d6"}}</option>
         </select>
     </div>
 
     <div class="form-group">
         <label>{{localize "age-system.setDmgExtraDice"}}</label>
         <select name="setDmgExtraDice">
-            <option value="0"{{#if (eq "0" setDmgExtraDice)}} selected{{/1f}}>-</option>
-            <option value="1"{{#if (eq "1" setDmgExtraDice)}} selected{{/1f}}>1{{localize "age-system.settings.d6"}}</option>
-            <option value="2"{{#if (eq "2" setDmgExtraDice)}} selected{{/1f}}>2{{localize "age-system.settings.d6"}}</option>
-            <option value="3"{{#if (eq "3" setDmgExtraDice)}} selected{{/1f}}>3{{localize "age-system.settings.d6"}}</option>
-            <option value="4"{{#if (eq "4" setDmgExtraDice)}} selected{{/1f}}>4{{localize "age-system.settings.d6"}}</option>
-            <option value="5"{{#if (eq "5" setDmgExtraDice)}} selected{{/1f}}>5{{localize "age-system.settings.d6"}}</option>
-            <option value="6"{{#if (eq "6" setDmgExtraDice)}} selected{{/1f}}>6{{localize "age-system.settings.d6"}}</option>
-            <option value="7"{{#if (eq "7" setDmgExtraDice)}} selected{{/1f}}>7{{localize "age-system.settings.d6"}}</option>
-            <option value="8"{{#if (eq "8" setDmgExtraDice)}} selected{{/1f}}>8{{localize "age-system.settings.d6"}}</option>
-            <option value="9"{{#if (eq "9" setDmgExtraDice)}} selected{{/1f}}>9{{localize "age-system.settings.d6"}}</option>
-            <option value="10"{{#if (eq "10" setDmgExtraDice)}} selected{{/1f}}>10{{localize "age-system.settings.d6"}}</option>
+            <option value="0"{{#if (eq "0" setDmgExtraDice)}} selected{{/if}}>-</option>
+            <option value="1"{{#if (eq "1" setDmgExtraDice)}} selected{{/if}}>1{{localize "age-system.settings.d6"}}</option>
+            <option value="2"{{#if (eq "2" setDmgExtraDice)}} selected{{/if}}>2{{localize "age-system.settings.d6"}}</option>
+            <option value="3"{{#if (eq "3" setDmgExtraDice)}} selected{{/if}}>3{{localize "age-system.settings.d6"}}</option>
+            <option value="4"{{#if (eq "4" setDmgExtraDice)}} selected{{/if}}>4{{localize "age-system.settings.d6"}}</option>
+            <option value="5"{{#if (eq "5" setDmgExtraDice)}} selected{{/if}}>5{{localize "age-system.settings.d6"}}</option>
+            <option value="6"{{#if (eq "6" setDmgExtraDice)}} selected{{/if}}>6{{localize "age-system.settings.d6"}}</option>
+            <option value="7"{{#if (eq "7" setDmgExtraDice)}} selected{{/if}}>7{{localize "age-system.settings.d6"}}</option>
+            <option value="8"{{#if (eq "8" setDmgExtraDice)}} selected{{/if}}>8{{localize "age-system.settings.d6"}}</option>
+            <option value="9"{{#if (eq "9" setDmgExtraDice)}} selected{{/if}}>9{{localize "age-system.settings.d6"}}</option>
+            <option value="10"{{#if (eq "10" setDmgExtraDice)}} selected{{/if}}>10{{localize "age-system.settings.d6"}}</option>
         </select>
     </div>
 

--- a/templates/rolls/dmg-roll-settings.hbs
+++ b/templates/rolls/dmg-roll-settings.hbs
@@ -3,12 +3,8 @@
     <div class="form-group">
         <label>Select Ability</label>
         <select name="selectedAbl">
-            {{#select selectedAbl}}
             <option value="no-abl">—</option>
-            {{#each abilities as |name key|}}
-            <option value="{{key}}">{{name}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions abilities selected=selectedAbl localize=true}}
         </select>
     </div>
     {{/if}}

--- a/templates/rolls/dmg-roll-settings.hbs
+++ b/templates/rolls/dmg-roll-settings.hbs
@@ -12,30 +12,26 @@
     <div class="form-group">
         <label>{{localize "age-system.setStuntDmg"}}</label>
         <select name="setStuntDamage">
-            {{#select data.diceType}}
-            <option value="0">-</option>
-            <option value="1">1{{localize "age-system.settings.d6"}}</option>
-            <option value="2">2{{localize "age-system.settings.d6"}}</option>
-            {{/select}}
+            <option value="0"{{#if (eq "0" data.diceType)}} selected{{/1f}}>-</option>
+            <option value="1"{{#if (eq "1" data.diceType)}} selected{{/1f}}>1{{localize "age-system.settings.d6"}}</option>
+            <option value="2"{{#if (eq "2" data.diceType)}} selected{{/1f}}>2{{localize "age-system.settings.d6"}}</option>
         </select>
     </div>
 
     <div class="form-group">
         <label>{{localize "age-system.setDmgExtraDice"}}</label>
         <select name="setDmgExtraDice">
-            {{#select setDmgExtraDice}}
-            <option value="0">-</option>
-            <option value="1">1{{localize "age-system.settings.d6"}}</option>
-            <option value="2">2{{localize "age-system.settings.d6"}}</option>
-            <option value="3">3{{localize "age-system.settings.d6"}}</option>
-            <option value="4">4{{localize "age-system.settings.d6"}}</option>
-            <option value="5">5{{localize "age-system.settings.d6"}}</option>
-            <option value="6">6{{localize "age-system.settings.d6"}}</option>
-            <option value="7">7{{localize "age-system.settings.d6"}}</option>
-            <option value="8">8{{localize "age-system.settings.d6"}}</option>
-            <option value="9">9{{localize "age-system.settings.d6"}}</option>
-            <option value="10">10{{localize "age-system.settings.d6"}}</option>
-            {{/select}}
+            <option value="0"{{#if (eq "0" setDmgExtraDice)}} selected{{/1f}}>-</option>
+            <option value="1"{{#if (eq "1" setDmgExtraDice)}} selected{{/1f}}>1{{localize "age-system.settings.d6"}}</option>
+            <option value="2"{{#if (eq "2" setDmgExtraDice)}} selected{{/1f}}>2{{localize "age-system.settings.d6"}}</option>
+            <option value="3"{{#if (eq "3" setDmgExtraDice)}} selected{{/1f}}>3{{localize "age-system.settings.d6"}}</option>
+            <option value="4"{{#if (eq "4" setDmgExtraDice)}} selected{{/1f}}>4{{localize "age-system.settings.d6"}}</option>
+            <option value="5"{{#if (eq "5" setDmgExtraDice)}} selected{{/1f}}>5{{localize "age-system.settings.d6"}}</option>
+            <option value="6"{{#if (eq "6" setDmgExtraDice)}} selected{{/1f}}>6{{localize "age-system.settings.d6"}}</option>
+            <option value="7"{{#if (eq "7" setDmgExtraDice)}} selected{{/1f}}>7{{localize "age-system.settings.d6"}}</option>
+            <option value="8"{{#if (eq "8" setDmgExtraDice)}} selected{{/1f}}>8{{localize "age-system.settings.d6"}}</option>
+            <option value="9"{{#if (eq "9" setDmgExtraDice)}} selected{{/1f}}>9{{localize "age-system.settings.d6"}}</option>
+            <option value="10"{{#if (eq "10" setDmgExtraDice)}} selected{{/1f}}>10{{localize "age-system.settings.d6"}}</option>
         </select>
     </div>
 

--- a/templates/sheets/age-active-effect-config.hbs
+++ b/templates/sheets/age-active-effect-config.hbs
@@ -124,8 +124,8 @@
                     </select>
                 </div>
                 <div class="mode">
-                    <select name="changes.{{i}}.mode" data-dtype="Number">
-                        {{selectOptions ../modes selected=change.mode}}
+                    <select name="changes.{{i}}.type">
+                        {{selectOptions ../modes selected=change.type}}
                     </select>
                 </div>
                 <div class="value">

--- a/templates/sheets/char/effects.hbs
+++ b/templates/sheets/char/effects.hbs
@@ -21,7 +21,7 @@
                         {{#each condition.changes as |change|}}
                         <li>
                             <span>
-                                {{#if change.key}}{{change.key}}{{else}}-{{/if}} ({{effectModeName change.mode}}, {{#if change.key}}{{change.value}}{{else}}-{{/if}})
+                                {{#if change.key}}{{change.key}}{{else}}-{{/if}} ({{effectModeName change.type}}, {{#if change.key}}{{change.value}}{{else}}-{{/if}})
                             </span>
                         </li>
                         {{/each}}
@@ -62,7 +62,7 @@
             </div>
             <div class="flexcol effect-operation">
                 {{#each effect.changes as |change|}}
-                <span>{{effectModeName change.mode}}</span>
+                <span>{{effectModeName change.type}}</span>
                 {{/each}}
             </div>
             <div class="flexcol effect-value">

--- a/templates/sheets/focus-sheet.hbs
+++ b/templates/sheets/focus-sheet.hbs
@@ -44,17 +44,11 @@
                 <div class="sub-details flexrow">
                     <div class="flexcol minimum-length">
                         <select name="system.useAbl" class="header-input">
-                            {{#select system.useAbl}}
                             {{#if system.isOrg}}
-                            {{#each config.abilitiesOrg as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
+                            {{selectOptions config.abiliesOrg selected=value localize=true}}
                             {{else}}
-                            {{#each config.abilities as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
+                            {{selectOptions config.abilities selected=value localize=true}}
                             {{/if}}
-                            {{/select}}
                         </select>
                         <label class="label-under">{{localize "age-system.abl"}}</label>
                     </div>

--- a/templates/sheets/focus-sheet.hbs
+++ b/templates/sheets/focus-sheet.hbs
@@ -45,9 +45,9 @@
                     <div class="flexcol minimum-length">
                         <select name="system.useAbl" class="header-input">
                             {{#if system.isOrg}}
-                            {{selectOptions config.abiliesOrg selected=value localize=true}}
+                            {{selectOptions config.abiliesOrg selected=system.useAbl localize=true}}
                             {{else}}
-                            {{selectOptions config.abilities selected=value localize=true}}
+                            {{selectOptions config.abilities selected=system.useAbl localize=true}}
                             {{/if}}
                         </select>
                         <label class="label-under">{{localize "age-system.abl"}}</label>

--- a/templates/sheets/focus-sheet.hbs
+++ b/templates/sheets/focus-sheet.hbs
@@ -45,7 +45,7 @@
                     <div class="flexcol minimum-length">
                         <select name="system.useAbl" class="header-input">
                             {{#if system.isOrg}}
-                            {{selectOptions config.abiliesOrg selected=system.useAbl localize=true}}
+                            {{selectOptions config.abilitiesOrg selected=system.useAbl localize=true}}
                             {{else}}
                             {{selectOptions config.abilities selected=system.useAbl localize=true}}
                             {{/if}}

--- a/templates/sheets/organization-sheet.hbs
+++ b/templates/sheets/organization-sheet.hbs
@@ -40,11 +40,7 @@
             <input type="number" name="system.combat.stability.value" value="{{system.combat.stability.value}}" data-dtype="Number" />
             <span class="flexrow flex-align-center">
                 <select name="system.scope">
-                    {{#select system.scope}}
-                    {{#each config.orgScope as |name scope|}}
-                    <option value="{{scope}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.orgScope selected=system.scope localize=true}}
                 </select>
             </span>
         </li>

--- a/templates/sheets/power-sheet.hbs
+++ b/templates/sheets/power-sheet.hbs
@@ -47,11 +47,13 @@
             <li>
                 <label>{{localize "age-system.item.cast"}}</label>
                 <select name="system.castTime" class="data-input">
-                {{#select system.castTime}}
                     {{#each config.actionsToCast as |actionsToCast|}}
-                    <option value="{{@key}}">{{localize actionsToCast}}</option>
+                    {{#if eq @key system.castTime}}
+                    <option value="{{@key}}" selected>{{localize actionsToCast}}</option>
+                    {{else}}
+                    <option value="{{@key}}" selected>{{localize actionsToCast}}</option>
+                    {{/if}}
                     {{/each}}
-                {{/select}}
                 </select>
             </li>
 

--- a/templates/sheets/power-sheet.hbs
+++ b/templates/sheets/power-sheet.hbs
@@ -151,12 +151,8 @@
                             <label>{{config.POWER_FLAVOR.force}}</label>
                             <span class="minimal-input">{{system.itemForce}}</span>
                             <select name="system.itemForceAbl" class="extra-input">
-                                {{#select system.itemForceAbl}}
                                 <option value="no-abl">—</option>
-                                {{#each config.abilities as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.abilities selected=system.itemForceAbl localize=true}}
                             </select>
 
                             {{#unless (and system.inputFatigueTN system.useFatigue fatigueSet)}}
@@ -174,12 +170,8 @@
                         <li class="colorset-third-tier flexrow">
                             <label for="">{{localize "age-system.ablFatigue"}}</label>
                             <select name="system.ablFatigue">
-                                {{#select system.ablFatigue}}
                                 <option value="no-abl">—</option>
-                                {{#each config.abilities as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.abilities selected=system.ablFatigue localize=true}}
                             </select>
                         </li>
                         {{/if}}
@@ -189,12 +181,8 @@
                             <label>{{localize "age-system.item.testResist"}}</label>
                             {{!-- Ability to Resist Power --}}
                             <select name="system.testAbl" class="extra-input">
-                                {{#select system.testAbl}}
                                 <option value="no-abl">-</option>
-                                {{#each config.abilities as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.abilities selected=system.testAbl localize=true}}
                             </select>
                             {{!-- Focus to Resist Power --}}
                             <input name="system.testFocus" type="text" value="{{system.testFocus}}" placeholder="{{localize "age-system.focus"}}" list="{{item.type}}-{{item._id}}-list-resist"/>
@@ -224,12 +212,8 @@
                             {{/if}}
                             <div class="extra-input">
                                 <span>+<select name="system.dmgAbl">
-                                    {{#select system.dmgAbl}}
                                     <option value="no-abl">—</option>
-                                    {{#each config.abilities as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.abilities selected=system.dmgAbl localize=true}}
                                 </select></span>
                             </div>
                         </li>
@@ -244,12 +228,8 @@
                             {{/if}}
                             <div class="extra-input">
                                 <span>+<select name="system.damageResisted.dmgAbl">
-                                    {{#select system.damageResisted.dmgAbl}}
                                     <option value="no-abl">—</option>
-                                    {{#each config.abilities as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.abilities selected=system.damageResisted.dmgAbl localize=true}}
                                 </select></span>
                             </div>
                         </li>
@@ -260,19 +240,11 @@
                             <label class="colorset-third-tier">{{localize "age-system.type"}}</label>
                             {{#if config.healthSys.useBallistic}}
                             <select name="system.dmgType">
-                                {{#select system.dmgType}}
-                                {{#each config.damageType as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.damageType selected=system.dmgType localize=true}}
                             </select>
                             {{/if}}
                             <select name="system.dmgSource">
-                                {{#select system.dmgSource}}
-                                {{#each config.damageSource as |name source|}}
-                                <option value="{{source}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.damageSource selected=system.dmgSource localize=true}}
                             </select>
                         </li>
                         {{/if}}

--- a/templates/sheets/power-sheet.hbs
+++ b/templates/sheets/power-sheet.hbs
@@ -51,7 +51,7 @@
                     {{#if eq @key system.castTime}}
                     <option value="{{@key}}" selected>{{localize actionsToCast}}</option>
                     {{else}}
-                    <option value="{{@key}}" selected>{{localize actionsToCast}}</option>
+                    <option value="{{@key}}">{{localize actionsToCast}}</option>
                     {{/if}}
                     {{/each}}
                 </select>

--- a/templates/sheets/power-sheet.hbs
+++ b/templates/sheets/power-sheet.hbs
@@ -48,11 +48,7 @@
                 <label>{{localize "age-system.item.cast"}}</label>
                 <select name="system.castTime" class="data-input">
                     {{#each config.actionsToCast as |actionsToCast|}}
-                    {{#if eq @key system.castTime}}
-                    <option value="{{@key}}" selected>{{localize actionsToCast}}</option>
-                    {{else}}
-                    <option value="{{@key}}">{{localize actionsToCast}}</option>
-                    {{/if}}
+                    <option value="{{@key}}" {{#if (eq @key system.castTime)}}selected{{/if}}>{{localize actionsToCast}}</option>
                     {{/each}}
                 </select>
             </li>

--- a/templates/sheets/shipfeatures-sheet.hbs
+++ b/templates/sheets/shipfeatures-sheet.hbs
@@ -49,11 +49,7 @@
                 {{#if (eq system.type "rollable")}}
                 <label>{{localize "age-system.abl"}}</label>
                 <select name="system.useAbl" class="data-input">
-                    {{#select system.useAbl}}
-                    {{#each config.abilities as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.abilities selected=system.useAbl localize=true}}
                 </select>
                 {{/if}}
             </li>

--- a/templates/sheets/shipfeatures-sheet.hbs
+++ b/templates/sheets/shipfeatures-sheet.hbs
@@ -7,10 +7,8 @@
             <li>
                 <label>{{localize "age-system.spaceship.qualityType"}}</label>
                 <select name="system.quality">
-                    {{#select system.quality}}
-                    <option value="quality">{{localize "age-system.spaceship.quality"}}</option>
-                    <option value="flaw">{{localize "age-system.spaceship.flaw"}}</option>
-                    {{/select}}
+                    <option value="quality"{{#if (eq "quality" system.quality)}} selected{{/if}}>{{localize "age-system.spaceship.quality"}}</option>
+                    <option value="flaw"{{#if (eq "flaw" system.quality)}} selected{{/if}}>{{localize "age-system.spaceship.flaw"}}</option>
                 </select>
             </li>
 
@@ -70,11 +68,7 @@
                 <div class="sub-details flexrow">
                     <div class="flexcol minimum-length">
                         <select name="system.type" class="header-input">
-                        {{#select system.type}}
-                            {{#each config.featuresTypeLocal as |feature|}}
-                            <option value="{{feature.key}}">{{feature.name}}</option>
-                            {{/each}}
-                        {{/select}}
+                            {{selectOptions config.featuresTypeLocal selected=system.type valueAttr="key" labelAttr="name"}}
                         </select>
                         <label class="label-under">{{localize "age-system.spaceship.featuresType"}}</label>
                     </div>

--- a/templates/sheets/spaceship-sheet.hbs
+++ b/templates/sheets/spaceship-sheet.hbs
@@ -39,11 +39,7 @@
                     {{/select}}
                 </select>
                 <select name="system.systems.{{sysName}}.useAbl" class="system-abl">
-                    {{#select system.useAbl}}
-                    {{#each ../data.config.abilities as |name type|}}
-                    <option value="{{type}}">{{name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions ../data.config.abilities selected=system.useAbl localize=true}}
                 </select>
                 <input name="system.systems.{{sysName}}.useFocus" class="system-focus" type="text" value="{{system.useFocus}}" placeholder="{{localize "age-system.focus"}}" list="{{../this.actor.type}}-{{../this.actor.id}}-list"/>
             </li>

--- a/templates/sheets/spaceship-sheet.hbs
+++ b/templates/sheets/spaceship-sheet.hbs
@@ -31,12 +31,8 @@
                     <a class="system-roll roll-maneuver data-sys-name={{sysName}}" data-sys-box="1"><i class="fas fa-dice"></i></a>
                 </p>
                 <select name="system.systems.{{sysName}}.operator" class="system-operator">
-                    {{#select system.operator}}
-                    <option value="crew">{{localize "age-system.spaceship.crew"}}</option>
-                    {{#each ../data.passengers as |passenger|}}
-                    <option value="{{passenger.id}}">{{passenger.name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    <option value="crew"{{#if (eq "crew" system.operator)}} selected{{/if}}>{{localize "age-system.spaceship.crew"}}</option>
+                    {{selectOptions ../data.passengers selected=system.operator valueAttr="id" labelAttr="name"}}
                 </select>
                 <select name="system.systems.{{sysName}}.useAbl" class="system-abl">
                     {{selectOptions ../data.config.abilities selected=system.useAbl localize=true}}
@@ -72,11 +68,9 @@
                     <div class="flexrow flex-align-center flex-justify-center crew-competence">
                         <label class="competence-label">{{localize "age-system.spaceship.competence"}}</label>
                         <select class="competence-list" name="system.crew.competence">
-                            {{#select system.crew.competence}}
                             {{#each data.config.spaceshipCrewCompetence as |compet competKey|}}
-                            <option value="{{compet}}">{{localize (concat "age-system.spaceship.competenceLevel." competKey)}} (+{{compet}})</option>
+                            <option value="{{compet}}"{{#if (eq compat system.crew.competencce)}} selected{{/if}}>{{localize (concat "age-system.spaceship.competenceLevel." competKey)}} (+{{compet}})</option>
                             {{/each}}
-                            {{/select}}
                         </select>
                     </div>
                 </div>
@@ -89,11 +83,9 @@
                     <div class="flexrow flex-align-center size">
                         <label class="hull-label">{{localize "age-system.spaceship.size"}}</label>
                         <select class="ship-size" name="system.size" class="dice-size">
-                            {{#select system.size}}
                             {{#each data.config.spaceshipSize as |size sizeKey|}}
-                            <option value="{{size}}">{{localize (concat "age-system.spaceship.sizeType." sizeKey)}}</option>
+                            <option value="{{size}}"{{#if (eq size system.size)}} selected{{/if}}>{{localize (concat "age-system.spaceship.sizeType." sizeKey)}}</option>
                             {{/each}}
-                            {{/select}}
                         </select>
                     </div>
                     <div class="flexrow flex-align-center">

--- a/templates/sheets/stunts-sheet.hbs
+++ b/templates/sheets/stunts-sheet.hbs
@@ -20,10 +20,8 @@
             <li>
                 <label>{{localize "age-system.item.cost"}}</label>
                 <select name="system.costType">
-                {{#select system.costType}}
-                    <option value="fixed">{{localize "age-system.fixed"}}</option>
-                    <option value="variable">{{localize "age-system.variable"}}</option>
-                {{/select}}
+                    <option value="fixed"{{#if eq "fixed" system.costType}} selected{{/if}}>{{localize "age-system.fixed"}}</option>
+                    <option value="variable"{{#if eq "variable" system.costType}} selected{{/if}}>{{localize "age-system.variable"}}</option>
                 </select>
             </li>
 

--- a/templates/sheets/stunts-sheet.hbs
+++ b/templates/sheets/stunts-sheet.hbs
@@ -20,8 +20,8 @@
             <li>
                 <label>{{localize "age-system.item.cost"}}</label>
                 <select name="system.costType">
-                    <option value="fixed"{{#if eq "fixed" system.costType}} selected{{/if}}>{{localize "age-system.fixed"}}</option>
-                    <option value="variable"{{#if eq "variable" system.costType}} selected{{/if}}>{{localize "age-system.variable"}}</option>
+                    <option value="fixed"{{#if (eq "fixed" system.costType)}} selected{{/if}}>{{localize "age-system.fixed"}}</option>
+                    <option value="variable"{{#if (eq "variable" system.costType)}} selected{{/if}}>{{localize "age-system.variable"}}</option>
                 </select>
             </li>
 

--- a/templates/sheets/talent-sheet.hbs
+++ b/templates/sheets/talent-sheet.hbs
@@ -7,7 +7,7 @@
                 <label>{{localize "age-system.talentDegree"}}</label>
                 <select name="system.degree">
                     {{#each config.talentDegrees.inUse as |degree|}}
-                    <option value="{{@key}}"{{#if eq @key system.degree}} selected{{/if}}>{{degree}}</option>
+                    <option value="{{@key}}"{{#if (eq @key system.degree)}} selected{{/if}}>{{degree}}</option>
                     {{/each}}
                 </select>
             </li>
@@ -16,8 +16,8 @@
             <li>
                 <label>{{localize "age-system.type"}} </label>
                 <select name="system.type">
-                    <option value="talent"{{#if eq "talent" system.type}} selected{{/if}}>{{localize "TYPES.Item.talent"}}</option>
-                    <option value="spec"{{#if eq "spec" system.type}} selected{{/if}}>{{localize "age-system.item.spec"}}</option>
+                    <option value="talent"{{#if (eq "talent" system.type)}} selected{{/if}}>{{localize "TYPES.Item.talent"}}</option>
+                    <option value="spec"{{#if (eq "spec" system.type)}} selected{{/if}}>{{localize "age-system.item.spec"}}</option>
                 </select>
             </li>
 

--- a/templates/sheets/talent-sheet.hbs
+++ b/templates/sheets/talent-sheet.hbs
@@ -6,11 +6,9 @@
             <li>
                 <label>{{localize "age-system.talentDegree"}}</label>
                 <select name="system.degree">
-                {{#select system.degree}}
                     {{#each config.talentDegrees.inUse as |degree|}}
-                    <option value="{{@key}}">{{degree}}</option>
+                    <option value="{{@key}}"{{#if eq @key system.degree}} selected{{/if}}>{{degree}}</option>
                     {{/each}}
-                {{/select}}
                 </select>
             </li>
 
@@ -18,10 +16,8 @@
             <li>
                 <label>{{localize "age-system.type"}} </label>
                 <select name="system.type">
-                {{#select system.type}}
-                    <option value="talent">{{localize "TYPES.Item.talent"}}</option>
-                    <option value="spec">{{localize "age-system.item.spec"}}</option>
-                {{/select}}
+                    <option value="talent"{{#if eq "talent" system.type}} selected{{/if}}>{{localize "TYPES.Item.talent"}}</option>
+                    <option value="spec"{{#if eq "spec" system.type}} selected{{/if}}>{{localize "age-system.item.spec"}}</option>
                 </select>
             </li>
 

--- a/templates/sheets/vehicle-sheet.hbs
+++ b/templates/sheets/vehicle-sheet.hbs
@@ -19,13 +19,9 @@
             <div class="flexrow conductor-selection">
                 <label class="conductor">{{localize "age-system.conductor"}}</label>
                 <select class="conductor" name="system.conductor">
-                    {{#select system.conductor}}
-                    <option value="">{{localize "age-system.noAction"}}</option>
-                    <option value="synth-vehicle">Token</option>
-                    {{#each data.passengers as |passenger|}}
-                    <option value="{{passenger.id}}">{{passenger.name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    <option value=""{{#if (eq "" system.conductor)}} selected{{/if}}>{{localize "age-system.noAction"}}</option>
+                    <option value="synth-vehicle"{{#if (eq "synth-vehicle" system.conductor)}} selected{{/if}}>Token</option>
+                    {{selectOptions data.passengers selected=system.conductor valueAttr="id" labelAttr="name"}}
                 </select>
             </div>
 
@@ -52,12 +48,8 @@
                     <label>{{localize "age-system.velocity"}}</label>
                     <div class="flexrow no-flexwrap">
                         <select name="system.velocity.category">
-                            {{#select system.velocity.category}}
-                            {{#each data.config.velocityCategory as |category|}}
-                            <option value="{{@key}}">{{localize (concat "age-system." @key)}}</option>
-                            {{/each}}
-                            <option value="velCustom">{{localize (concat "age-system.velCustom")}}</option>
-                            {{/select}}
+                            <option value="{{@key}}"{{#if (eq @key system.valocity.category)}} selected{{/if}}>{{localize (concat "age-system." @key)}}</option>
+                            <option value="velCustom"{{#if (eq "velCustom" system.valocity.category)}} selected{{/if}}>{{localize (concat "age-system.velCustom")}}</option>
                         </select>    
                         <span>/</span>
                         <input type="number" name="system.velocity.catMod" value="{{system.velocity.catMod}}" data-dtype="Number">

--- a/templates/sheets/vehicle-sheet.hbs
+++ b/templates/sheets/vehicle-sheet.hbs
@@ -36,11 +36,7 @@
                     <a class="roll-maneuver"><i class="fas fa-dice"></i></a>
                 </div>
                 <select name="system.handling.useAbl" class="data-input">
-                    {{#select system.handling.useAbl}}
-                    {{#each data.config.abilities as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions data.config.abilities selected=system.handling.useAbl localize=true}}
                 </select>
                 <input type="text" name="system.handling.useFocus" value="{{system.handling.useFocus}}" list="{{name}}-{{actor.id}}-list" placeholder="{{localize "age-system.focus"}}">
                 <datalist id="{{name}}-{{actor.id}}-list">

--- a/templates/sheets/weapon-sheet.hbs
+++ b/templates/sheets/weapon-sheet.hbs
@@ -44,11 +44,9 @@
             <li>
                 <label>{{localize "age-system.rof.rof"}}</label>
                 <select name="system.rof">
-                    {{#select system.rof}}
                     {{#each config.rof as |rof|}}
-                    <option value="{{@key}}">{{localize rof}}</option>
+                    <option value="{{@key}}"{{#if (eq @key system.rof)}} selected{{/if}}>{{localize rof}}</option>
                     {{/each}}
-                    {{/select}}
                 </select>             
             </li>
             {{#unless (or (eq system.rof "none") (eq system.rof "singleShot"))}}
@@ -65,11 +63,9 @@
                 <div>{{localize (concat "age-system." system.reload)}}</div>
                 {{else}}
                 <select name="system.reload" {{#if inChat}}disabled{{/if}}>
-                    {{#select system.reload}}
                     {{#each config.reloadDuration as |reloadDuration|}}
-                    <option value="{{@key}}">{{localize reloadDuration}}</option>
+                    <option value="{{@key}}"{{#if (eq @key system.relaod)}} selected{{/if}}>{{localize reloadDuration}}</option>
                     {{/each}}
-                    {{/select}}
                 </select>    
                 {{/if}}                   
             </li>

--- a/templates/sheets/weapon-sheet.hbs
+++ b/templates/sheets/weapon-sheet.hbs
@@ -143,12 +143,8 @@
                             {{/if}}
                             <div class="extra-input">
                                 <span>+<select name="system.dmgAbl">
-                                    {{#select system.dmgAbl}}
                                     <option value="no-abl">—</option>
-                                    {{#each config.abilities as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.abilities selected=system.dmgAbl localize=true}}
                                 </select></span>
                             </div>
                         </li>
@@ -156,19 +152,11 @@
                             <label class="colorset-third-tier">{{localize "age-system.type"}}</label>
                             {{#if config.healthSys.useBallistic}}
                             <select name="system.dmgType">
-                                {{#select system.dmgType}}
-                                {{#each config.damageType as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.damageType selected=system.dmgType localize=true}}
                             </select>
                             {{/if}}
                             <select name="system.dmgSource">
-                                {{#select system.dmgSource}}
-                                {{#each config.damageSource as |name source|}}
-                                <option value="{{source}}">{{localize name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.damageSource selected=system.dmgSource localize=true}}
                             </select>
                         </li>
                     </ul>


### PR DESCRIPTION
Foundry v14 discontinued select helper in favor to selectOptions templates had to move.

All small deprecation warnings are handled.

To be fixed later
* template.json -> system.json and DataModels (Huge change with migrations)
* AppV1-> AppV2